### PR TITLE
refactor: extract timeline UI into components and hooks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,46 +1,32 @@
 "use client";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { isObjectId } from "./utils/isObjectId";
 import {
-  Calendar as CalendarIcon,
-  Plus,
-  Search,
-  Tag,
   Upload,
   Sparkles,
-  Filter,
-  X,
   SunMedium,
   MoonStar,
   ChevronLeft,
   ChevronRight,
-  Edit3,
   Trash2,
-  Wand2,
   LogIn,
   LogOut,
-  Image as ImageIcon,
-  Info,
   ArrowDown,
   Settings,
   FileJson,
   FileDown,
 } from "lucide-react";
-
-/* =========================
-   Типы данных
-========================= */
-type EventItem = {
-  id: string;
-  date: string; // ISO 8601: YYYY-MM-DD
-  title: string;
-  description?: string;
-  tags: string[];
-  color?: string;
-  emoji?: string; // устар.
-  imageData?: string;
-};
+import { Button, Dialog, ConfirmDialog } from "./components/ui";
+import FiltersPanel from "./components/FiltersPanel";
+import EventList from "./components/EventList";
+import AuthDialog from "./components/AuthDialog";
+import AddDialog from "./components/AddDialog";
+import DetailDialog from "./components/DetailDialog";
+import { useEventFilters } from "./hooks/useEventFilters";
+import { useDialogs } from "./hooks/useDialogs";
+import { EventItem } from "./types";
+import { formatDateHuman, uid, downloadFile, toICS } from "./utils/helpers";
 
 /* =========================
    API клиент (server-mode)
@@ -105,82 +91,6 @@ const api = {
 ========================= */
 const THEME_KEY = "life-timeline-theme";
 
-function uid() {
-  return Math.random().toString(36).slice(2) + Date.now().toString(36);
-}
-function formatDateHuman(iso: string) {
-  const d = new Date(iso);
-  return d.toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
-}
-function getYear(iso: string) {
-  return new Date(iso).getFullYear();
-}
-function getMonth(iso: string) {
-  return new Date(iso).getMonth();
-}
-
-function downloadFile(
-  filename: string,
-  content: string,
-  type = "application/json"
-) {
-  const blob = new Blob([content], { type });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
-}
-
-function toICS(events: EventItem[]) {
-  const lines = [
-    "BEGIN:VCALENDAR",
-    "VERSION:2.0",
-    "PRODID:-//Life Timeline//EN",
-  ];
-  for (const ev of events) {
-    const dt = new Date(ev.date);
-    const dtStart = dt.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
-    const dtEndDate = new Date(dt.getTime() + 24 * 60 * 60 * 1000);
-    const dtEnd =
-      dtEndDate.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
-    lines.push("BEGIN:VEVENT");
-    lines.push(`UID:${ev.id}@life-timeline`);
-    lines.push(`DTSTAMP:${dtStart}`);
-    lines.push(`DTSTART:${dtStart}`);
-    lines.push(`DTEND:${dtEnd}`);
-    lines.push(`SUMMARY:${ev.title}`);
-    if (ev.description)
-      lines.push(`DESCRIPTION:${ev.description.replace(/\n/g, "\\n")}`);
-    if (ev.tags?.length) lines.push(`CATEGORIES:${ev.tags.join(",")}`);
-    lines.push("END:VEVENT");
-  }
-  lines.push("END:VCALENDAR");
-  return lines.join("\n");
-}
-
-const MONTHS = [
-  "Январь",
-  "Февраль",
-  "Март",
-  "Апрель",
-  "Май",
-  "Июнь",
-  "Июль",
-  "Август",
-  "Сентябрь",
-  "Октябрь",
-  "Ноябрь",
-  "Декабрь",
-];
-
 /* =========================
    Примеры (локальный fallback)
 ========================= */
@@ -211,304 +121,6 @@ const SAMPLE: EventItem[] = [
   },
 ];
 
-/* =========================
-   Мини UI-компоненты
-========================= */
-function cn(...classes: (string | boolean | undefined | null)[]) {
-  return classes.filter(Boolean).join(" ");
-}
-
-function Button({
-  className,
-  children,
-  onClick,
-  variant = "primary",
-  type = "button",
-  disabled,
-}: React.PropsWithChildren<{
-  className?: string;
-  onClick?: () => void;
-  variant?: "primary" | "ghost" | "outline" | "soft";
-  type?: "button" | "submit" | "reset";
-  disabled?: boolean;
-}>) {
-  const base =
-    "inline-flex items-center gap-2 rounded-2xl px-4 py-2 text-sm font-medium shadow-sm transition active:scale-[.98]";
-  const variants: Record<string, string> = {
-    primary:
-      "bg-gradient-to-br from-indigo-500 to-fuchsia-500 text-white hover:opacity-95",
-    ghost:
-      "bg-transparent hover:bg-white/10 text-foreground dark:text-white border border-transparent",
-    outline:
-      "border border-black/10 dark:border-white/10 hover:bg-black/5 dark:hover:bg-white/10",
-    soft: "bg-black/5 dark:bg-white/10 hover:bg-black/10 dark:hover:bg-white/20",
-  };
-  return (
-    <button
-      type={type}
-      disabled={disabled}
-      onClick={onClick}
-      className={cn(
-        base,
-        variants[variant],
-        disabled && "opacity-60 cursor-not-allowed",
-        className
-      )}
-    >
-      {children}
-    </button>
-  );
-}
-
-function Chip({
-  selected,
-  label,
-  onClick,
-}: {
-  selected?: boolean;
-  label: string;
-  onClick?: () => void;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={cn(
-        "px-3 py-1 rounded-full text-xs border transition",
-        selected
-          ? "bg-indigo-500/90 text-white border-transparent"
-          : "bg-white/70 dark:bg-white/5 backdrop-blur border-black/10 dark:border-white/10 hover:bg-white"
-      )}
-    >
-      {label}
-    </button>
-  );
-}
-
-function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
-  return (
-    <input
-      {...props}
-      className={cn(
-        "w-full rounded-xl border border-black/10 dark:border-white/10 bg-white/80 dark:bg-white/5 px-3 py-2 text-sm outline-none",
-        "focus:ring-2 focus:ring-indigo-400/60",
-        props.className
-      )}
-    />
-  );
-}
-
-function Textarea(props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
-  return (
-    <textarea
-      {...props}
-      className={cn(
-        "w-full rounded-xl border border-black/10 dark:border-white/10 bg-white/80 dark:bg-white/5 px-3 py-2 text-sm outline-none",
-        "focus:ring-2 focus:ring-indigo-400/60",
-        props.className
-      )}
-    />
-  );
-}
-
-function Dialog({
-  open,
-  onClose,
-  children,
-}: React.PropsWithChildren<{ open: boolean; onClose: () => void }>) {
-  useEffect(() => {
-    if (!open) return;
-    const original = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = original;
-    };
-  }, [open]);
-
-  if (!open) return null;
-  return (
-    <div className="fixed inset-0 z-50 grid place-items-center">
-      <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-        onClick={onClose}
-      />
-      <motion.div
-        initial={{ y: 20, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        exit={{ y: 10, opacity: 0 }}
-        className="relative z-10 w-[92vw] max-w-2xl rounded-2xl border border-white/10 bg-white/95 shadow-2xl dark:bg-neutral-900/95"
-      >
-        <div className="flex max-h-[85vh] flex-col">{children}</div>
-      </motion.div>
-    </div>
-  );
-}
-/* ======= Подтверждение ======= */
-function ConfirmDialog({
-  open, title = "Вы уверены?", description, confirmText = "Да", cancelText = "Отмена",
-  onConfirm, onCancel,
-}: {
-  open: boolean;
-  title?: string;
-  description?: string;
-  confirmText?: string;
-  cancelText?: string;
-  onConfirm: () => void;
-  onCancel: () => void;
-}) {
-  if (!open) return null;
-  return (
-    <Dialog open={open} onClose={onCancel}>
-      <div className="p-4">
-        <h3 className="text-lg font-semibold">{title}</h3>
-        {description && <p className="mt-2 text-sm opacity-80">{description}</p>}
-        <div className="mt-4 flex justify-end gap-2">
-          <Button variant="outline" onClick={onCancel}><X size={16}/> {cancelText}</Button>
-          <Button onClick={onConfirm}><Sparkles size={16}/> {confirmText}</Button>
-        </div>
-      </div>
-    </Dialog>
-  );
-}
-
-/* ======= Диалог авторизации ======= */
-function AuthDialog({
-  open, mode, onClose, onSuccess,
-}: {
-  open: boolean;
-  mode: "login" | "register";
-  onClose: () => void;
-  onSuccess: () => void;
-}) {
-  const [form, setForm] = useState({ email: "", password: "", invite: "" });
-  const [showPass, setShowPass] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(()=>{ setError(null); }, [mode, open]);
-
-  async function submit() {
-    setLoading(true);
-    setError(null);
-    try {
-      if (mode === "login") {
-        await api.login(form.email, form.password);
-      } else {
-        if (!form.invite) { setError("Нужен инвайт-код"); setLoading(false); return; }
-        await api.register(form.email, form.password, form.invite);
-      }
-      onSuccess();
-      onClose();
-    } catch (e:any) {
-      setError(e?.message || "Ошибка авторизации");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  if (!open) return null;
-  return (
-    <Dialog open={open} onClose={onClose}>
-      <div className="sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-black/10 bg-white/95 px-4 py-3 dark:border-white/10 dark:bg-neutral-900/95">
-        <div className="flex items-center gap-2 text-lg font-semibold">
-          {mode === "login" ? <><LogIn size={18}/> Вход</> : <><Sparkles size={18}/> Регистрация</>}
-        </div>
-        <Button variant="ghost" onClick={onClose}><X size={18}/></Button>
-      </div>
-
-      <div className="p-4">
-        <div className="grid gap-3">
-          <div className="grid gap-1">
-            <label className="text-xs opacity-70">Email</label>
-            <Input
-              type="email"
-              placeholder="you@example.com"
-              value={form.email}
-              onChange={(e)=>setForm({...form, email: e.target.value})}
-            />
-          </div>
-
-          <div className="grid gap-1">
-            <label className="text-xs opacity-70">Пароль</label>
-            <div className="relative">
-              <Input
-                type={showPass ? "text" : "password"}
-                placeholder="••••••••"
-                value={form.password}
-                onChange={(e)=>setForm({...form, password: e.target.value})}
-                className="pr-10"
-              />
-              <button
-                type="button"
-                onClick={()=>setShowPass(v=>!v)}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-xs opacity-70 hover:opacity-100"
-              >
-                {showPass ? "Скрыть" : "Показать"}
-              </button>
-            </div>
-            <p className="text-[11px] opacity-60">Мин. 6 символов</p>
-          </div>
-
-          {mode === "register" && (
-            <div className="grid gap-1">
-              <label className="text-xs opacity-70">Инвайт-код</label>
-              <Input
-                placeholder="XXXX-XXXX"
-                value={form.invite}
-                onChange={(e)=>setForm({...form, invite: e.target.value})}
-              />
-            </div>
-          )}
-
-          {error && (
-            <div className="rounded-xl border border-red-200/60 bg-red-50/80 px-3 py-2 text-xs text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
-              {error}
-            </div>
-          )}
-
-          <div className="mt-1 flex items-center justify-between">
-            <button
-              type="button"
-              className="text-xs opacity-70 hover:opacity-100 underline underline-offset-4"
-              onClick={()=>{ /* тут можно сделать forgot password */ alert("Скоро добавим восстановление пароля 🙂"); }}
-            >
-              Забыли пароль?
-            </button>
-            <button
-              type="button"
-              className="text-xs opacity-70 hover:opacity-100 underline underline-offset-4"
-              onMouseDown={(e)=>e.preventDefault()}
-              onClickCapture={()=>{}}
-              onClick={()=>{
-                // переключаем режим без закрытия
-                // хак: не закрываем диалог, просто меняем state выше (через пропы нельзя, так что вынесем наружу)
-              }}
-            />
-          </div>
-        </div>
-
-        <div className="mt-4 flex items-center justify-between">
-          <div className="text-xs opacity-70">
-            {mode === "login" ? "Нет аккаунта?" : "Уже есть аккаунт?"}{" "}
-            <button
-              className="underline underline-offset-4 hover:opacity-100 opacity-80"
-              onClick={()=>{
-                // ничего не отправляем, просто переключим режим
-                const ev = new CustomEvent("switch-auth-mode", { detail: mode === "login" ? "register" : "login" });
-                window.dispatchEvent(ev);
-              }}
-            >
-              {mode === "login" ? "Зарегистрируйтесь" : "Войти"}
-            </button>
-          </div>
-
-          <Button onClick={submit} disabled={loading}>
-            {loading ? "..." : (mode === "login" ? (<><LogIn size={16}/> Войти</>) : (<><Sparkles size={16}/> Зарегистрироваться</>))}
-          </Button>
-        </div>
-      </div>
-    </Dialog>
-  );
-}
 /* ======= Parallax фон для hero ======= */
 function ParallaxBackground() {
   const ref = useRef<HTMLDivElement>(null);
@@ -600,91 +212,71 @@ export default function LifeTimelineApp() {
 
   // Данные теперь с сервера
   const [events, setEvents] = useState<EventItem[]>([]);
-  const [me, setMe] = useState<MeUser | null>(null);
-  const admin = Boolean(me);
+   const [me, setMe] = useState<MeUser | null>(null);
+   const admin = Boolean(me);
 
-  async function refreshMe() {
-    try {
-      const r = await api.me();
-      setMe(r.user);
-    } catch {
-      setMe(null);
-    }
-  }
-  async function refreshEvents() {
-    try {
-      const r = await api.getEvents();
-      setEvents(r.events || []);
-    } catch {
-      setEvents(SAMPLE); /* fallback чтобы не пусто */
-    }
-  }
+   async function refreshMe() {
+     try {
+       const r = await api.me();
+       setMe(r.user);
+     } catch {
+       setMe(null);
+     }
+   }
+   async function refreshEvents() {
+     try {
+       const r = await api.getEvents();
+       setEvents(r.events || []);
+     } catch {
+       setEvents(SAMPLE); /* fallback чтобы не пусто */
+     }
+   }
 
-  useEffect(() => {
-    refreshMe();
-    refreshEvents();
-  }, []);
+   useEffect(() => {
+     refreshMe();
+     refreshEvents();
+   }, []);
 
-  useEffect(()=>{
-  function onSwitch(e: any) {
-    const next = (e?.detail === "register") ? "register" : "login";
-    setAuthMode(next as any);
-  }
-  window.addEventListener("switch-auth-mode", onSwitch as any);
-  return ()=> window.removeEventListener("switch-auth-mode", onSwitch as any);
-},[]);
+   const {
+     query,
+     setQuery,
+     year,
+     setYear,
+     month,
+     setMonth,
+     activeTags,
+     setActiveTags,
+     view,
+     setView,
+     allTags,
+     years,
+     filtered,
+     prevYear,
+     nextYear,
+   } = useEventFilters(events);
 
-  // UI состояние
-  const [query, setQuery] = useState("");
-  const [year, setYear] = useState<number | "all">("all");
-  const [month, setMonth] = useState<number | "all">("all");
-  const [activeTags, setActiveTags] = useState<string[]>([]);
-  const [view, setView] = useState<"timeline" | "calendar">("timeline");
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [authOpen, setAuthOpen] = useState(false);
-  const [authMode, setAuthMode] = useState<"login" | "register">("login");
-  const [logoutConfirmOpen, setLogoutConfirmOpen] = useState(false);
-  const [editing, setEditing] = useState<EventItem | null>(null);
-  const [detailOpen, setDetailOpen] = useState(false);
-  const [selected, setSelected] = useState<EventItem | null>(null);
-  const [imagePreview, setImagePreview] = useState<string | null>(null);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [deleting, setDeleting] = useState<EventItem | null>(null);
-
-  // Фильтрация/поиск
-  const allTags = useMemo(() => {
-    const s = new Set<string>();
-    for (const e of events) e.tags.forEach((t) => s.add(t));
-    return Array.from(s).sort((a, b) => a.localeCompare(b));
-  }, [events]);
-
-  const years = useMemo(() => {
-    const ys = new Set<number>();
-    for (const e of events) ys.add(getYear(e.date));
-    return Array.from(ys).sort((a, b) => a - b);
-  }, [events]);
-
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return events
-      .filter((e) => (year === "all" ? true : getYear(e.date) === year))
-      .filter((e) => (month === "all" ? true : getMonth(e.date) === month))
-      .filter((e) =>
-        !activeTags.length
-          ? true
-          : activeTags.every((t) =>
-              e.tags.map((x) => x.toLowerCase()).includes(t.toLowerCase())
-            )
-      )
-      .filter((e) =>
-        !q
-          ? true
-          : [e.title, e.description, e.tags.join(" ")]
-              .filter(Boolean)
-              .some((s) => s!.toLowerCase().includes(q))
-      )
-      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-  }, [events, query, year, month, activeTags]);
+   const {
+     dialogOpen,
+     setDialogOpen,
+     authOpen,
+     setAuthOpen,
+     authMode,
+     setAuthMode,
+     logoutConfirmOpen,
+     setLogoutConfirmOpen,
+     editing,
+     setEditing,
+     detailOpen,
+     setDetailOpen,
+     selected,
+     setSelected,
+     imagePreview,
+     setImagePreview,
+     settingsOpen,
+     setSettingsOpen,
+     deleting,
+     setDeleting,
+   } = useDialogs();
 
   // Навигация с клавы
   const listRef = useRef<HTMLDivElement>(null);
@@ -806,339 +398,6 @@ export default function LifeTimelineApp() {
   setLogoutConfirmOpen(true);
 }
 
-  /* ======= UI: форма, карточки, сетки (без изменений по дизайну) ======= */
-  function EventForm({
-    initial,
-    onSubmit,
-    onCancel,
-  }: {
-    initial?: Partial<EventItem>;
-    onSubmit: (e: EventItem) => void;
-    onCancel: () => void;
-  }) {
-    const [date, setDate] = useState(
-      initial?.date || new Date().toISOString().slice(0, 10)
-    );
-    const [title, setTitle] = useState(initial?.title || "");
-    const [description, setDescription] = useState(initial?.description || "");
-    const [tags, setTags] = useState((initial?.tags as string[]) || []);
-    const [tagInput, setTagInput] = useState("");
-    const [color, setColor] = useState(initial?.color || "");
-    const [imageData, setImageData] = useState<string | undefined>(
-      initial?.imageData
-    );
-    const presetColors = [
-      "#60a5fa",
-      "#34d399",
-      "#f472b6",
-      "#fb923c",
-      "#a78bfa",
-      "#fbbf24",
-    ];
-    function addTag() {
-      const t = tagInput.trim();
-      if (!t) return;
-      if (!tags.includes(t)) setTags([...tags, t]);
-      setTagInput("");
-    }
-    function onFile(e: React.ChangeEvent<HTMLInputElement>) {
-      const file = e.target.files?.[0];
-      if (!file) return;
-      if (!file.type.startsWith("image/")) return alert("Выберите изображение");
-      const reader = new FileReader();
-      reader.onload = () => setImageData(String(reader.result));
-      reader.readAsDataURL(file);
-    }
-    return (
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          const ev: EventItem = {
-            id: (initial?.id as string) || uid(),
-            date,
-            title: title.trim() || "Без названия",
-            description: description.trim(),
-            tags,
-            color: color || undefined,
-            imageData,
-          };
-          onSubmit(ev);
-        }}
-        className="flex min-h-0 flex-1 flex-col"
-      >
-        <div className="grid max-h-[60vh] gap-3 overflow-y-auto pr-1">
-          <div className="grid gap-1">
-            <label className="text-xs text-black/60 dark:text-white/60">
-              Дата
-            </label>
-            <Input
-              type="date"
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-              required
-            />
-          </div>
-          <div className="grid gap-1">
-            <label className="text-xs text-black/60 dark:text-white/60">
-              Заголовок
-            </label>
-            <Input
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="Например: Переезд в новый город"
-            />
-          </div>
-          <div className="grid gap-1">
-            <label className="text-xs text-black/60 dark:text-white/60">
-              Описание
-            </label>
-            <Textarea
-              rows={4}
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Короткая история/заметки"
-            />
-          </div>
-          <div className="grid gap-1">
-            <label className="text-xs text-black/60 dark:text-white/60">
-              Теги
-            </label>
-            <div className="flex gap-2">
-              <Input
-                value={tagInput}
-                onChange={(e) => setTagInput(e.target.value)}
-                placeholder="Добавить тег"
-                onKeyDown={(e) =>
-                  e.key === "Enter" && (e.preventDefault(), addTag())
-                }
-              />
-              <Button variant="soft" onClick={addTag}>
-                <Tag size={16} />
-                Добавить
-              </Button>
-            </div>
-            <div className="flex flex-wrap gap-2 pt-1">
-              {tags.map((t) => (
-                <Chip
-                  key={t}
-                  label={t}
-                  onClick={() => setTags(tags.filter((x) => x !== t))}
-                />
-              ))}
-            </div>
-          </div>
-          <div className="grid gap-3">
-            <label className="text-xs text-black/60 dark:text-white/60">
-              Цвет акцента
-            </label>
-            <div className="flex flex-wrap items-center gap-3">
-              {[
-                "#60a5fa",
-                "#34d399",
-                "#f472b6",
-                "#fb923c",
-                "#a78bfa",
-                "#fbbf24",
-              ].map((c) => (
-                <button
-                  key={c}
-                  type="button"
-                  onClick={() => setColor(c)}
-                  className={cn(
-                    "h-6 w-6 rounded-full border border-black/20 dark:border-white/10",
-                    color === c && "ring-2 ring-offset-2 ring-indigo-400"
-                  )}
-                  style={{ background: c }}
-                  aria-label={`Выбрать цвет ${c}`}
-                />
-              ))}
-            </div>
-          </div>
-          <div className="grid gap-3">
-            <label className="text-xs text-black/60 dark:text-white/60 flex items-center gap-2">
-              <ImageIcon size={16} /> Фото (необязательно, 1 шт)
-            </label>
-            <div className="flex flex-col items-start gap-2">
-              <label
-                className={cn(
-                  "relative flex cursor-pointer items-center justify-center rounded-xl border-2 border-dashed border-indigo-300/60 bg-white/60 px-4 py-4 text-sm font-medium transition hover:bg-indigo-50 dark:bg-white/10 dark:hover:bg-indigo-950/20",
-                  imageData && "border-solid border-indigo-400 bg-indigo-50/60 dark:bg-indigo-900/30"
-                )}
-                style={{ minHeight: 120, minWidth: 180, width: "100%", maxWidth: 320 }}
-              >
-                {imageData ? (
-                  <img
-                    src={imageData}
-                    alt="Превью"
-                    className="h-28 w-full object-cover rounded-lg shadow"
-                  />
-                ) : (
-                  <div className="flex flex-col items-center justify-center w-full h-full gap-2 py-2 text-indigo-500 dark:text-indigo-300">
-                    <ImageIcon size={32} />
-                    <span className="text-xs opacity-70">Выбрать изображение</span>
-                  </div>
-                )}
-                <input
-                  type="file"
-                  accept="image/*"
-                  onChange={onFile}
-                  className="absolute inset-0 h-full w-full opacity-0 cursor-pointer"
-                  tabIndex={-1}
-                  aria-label="Выбрать изображение"
-                />
-              </label>
-              {imageData && (
-                <Button
-                  variant="outline"
-                  className="mt-1"
-                  onClick={() => setImageData(undefined)}
-                >
-                  <X size={14} /> Удалить фото
-                </Button>
-              )}
-            </div>
-          </div>
-        </div>
-        <div className="sticky bottom-0 -mx-4 mt-3 flex justify-end gap-2 border-t border-black/10 bg-white/90 px-4 py-3 backdrop-blur dark:border-white/10 dark:bg-neutral-900/90">
-          <Button variant="outline" onClick={onCancel}>
-            <X size={16} />
-            Отмена
-          </Button>
-          <Button type="submit">
-            <Sparkles size={16} />
-            Сохранить
-          </Button>
-        </div>
-      </form>
-    );
-  }
-
-  function EventCard({
-    ev,
-    className = "",
-  }: {
-    ev: EventItem;
-    className?: string;
-  }) {
-    const accent = ev.color || "#8b5cf6";
-    return (
-      <motion.button
-        layout
-        data-timeline-card
-        tabIndex={0}
-        onClick={() => {
-          setSelected(ev);
-          setDetailOpen(true);
-        }}
-        initial={{ y: 10, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        exit={{ y: -10, opacity: 0 }}
-        className={cn(
-          "group relative flex h-45 w-full flex-col overflow-hidden text-left rounded-3xl border border-black/5 p-5 shadow-lg backdrop-blur transition hover:shadow-2xl focus:outline-none focus:ring-2 focus:ring-indigo-300",
-          "bg-white/70 dark:bg-white/5",
-          className
-        )}
-        style={{
-          backgroundImage: `linear-gradient(180deg, ${accent}0f, transparent 55%)`,
-        }}
-      >
-        <div
-          className="absolute inset-x-4 top-0 h-1 rounded-b-full"
-          style={{ background: accent }}
-        />
-        <div className="flex items-start justify-between gap-3">
-          <div className="text-base font-semibold text-neutral-900 dark:text-white sm:text-lg">
-            {ev.title}
-          </div>
-          {admin && (
-            <div
-              className="flex items-center gap-2 opacity-90"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <Button
-                variant="soft"
-                onClick={() => {
-                  setEditing(ev);
-                  setDialogOpen(true);
-                }}
-              >
-                <Edit3 size={16} />
-              </Button>
-              <Button variant="outline" onClick={() => setDeleting(ev)}>
-                <Trash2 size={16} />
-              </Button>
-            </div>
-          )}
-        </div>
-        <div className="pt-1 text-sm text-neutral-700 dark:text-neutral-300">
-          <span className="inline-flex items-center gap-1 rounded-full bg-black/5 px-2 py-0.5 text-xs dark:bg-white/10">
-            <CalendarIcon size={14} /> {formatDateHuman(ev.date)}
-          </span>
-        </div>
-        {ev.description && (
-          <p className="pt-3 text-sm leading-relaxed text-neutral-800 dark:text-neutral-200 line-clamp-1">
-            {ev.description}
-          </p>
-        )}
-        {ev.tags?.length ? (
-          <div className="mt-auto pt-3 flex flex-wrap gap-2">
-            {ev.tags.map((t) => (
-              <span
-                key={t}
-                className="rounded-full bg-indigo-500/10 px-2 py-0.5 text-xs text-indigo-700 dark:text-indigo-300"
-                style={{ border: `1px solid ${accent}55` }}
-              >
-                #{t}
-              </span>
-            ))}
-          </div>
-        ) : null}
-      </motion.button>
-    );
-  }
-
-  function MonthGrid() {
-    const grouped: Record<number, EventItem[]> = {};
-    for (let i = 0; i < 12; i++) grouped[i] = [];
-    for (const ev of filtered) grouped[getMonth(ev.date)].push(ev);
-    return (
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {MONTHS.map((m, i) => (
-          <div
-            key={m}
-            className="rounded-3xl border border-black/10 bg-white/60 p-4 dark:border-white/10 dark:bg-white/5"
-          >
-            <div className="mb-3 flex items-center justify-between">
-              <div className="font-semibold text-neutral-900 dark:text-white">
-                {m}
-              </div>
-              <div className="text-xs opacity-60">
-                {grouped[i].length} событий
-              </div>
-            </div>
-            <div className="grid gap-2">
-              {grouped[i].length ? (
-                grouped[i].map((ev) => <EventCard key={ev.id} ev={ev} />)
-              ) : (
-                <div className="text-sm text-neutral-600 dark:text-neutral-400">
-                  Нет событий
-                </div>
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  const currentYearIndex = year === "all" ? -1 : years.indexOf(year);
-  function prevYear() {
-    if (currentYearIndex > 0) setYear(years[currentYearIndex - 1]);
-  }
-  function nextYear() {
-    if (currentYearIndex < years.length - 1)
-      setYear(years[currentYearIndex + 1]);
-  }
 
   return (
     <div className="min-h-dvh bg-gradient-to-br from-indigo-50 via-white to-rose-50 text-neutral-900 transition dark:from-[#0B0B12] dark:via-[#0B0B12] dark:to-[#14121B] dark:text-white">
@@ -1310,115 +569,30 @@ export default function LifeTimelineApp() {
         ref={timelineAnchorRef}
         className="mx-auto max-w-6xl mt-6 px-4 pb-24"
       >
-        <section className="-mt-6 mb-6 rounded-3xl border border-black/10 bg-white/70 p-4 shadow-xl backdrop-blur dark:border-white/10 dark:bg-white/5">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-1 items-center gap-2">
-              <div className="relative w-full">
-                <Search
-                  className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 opacity-60"
-                  size={18}
-                />
-                <Input
-                  className="pl-10"
-                  placeholder="Поиск по событиям, описаниям и тегам"
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                />
-              </div>
-              <Button
-                variant="soft"
-                onClick={() => {
-                  setActiveTags([]);
-                  setYear("all");
-                  setMonth("all");
-                  setQuery("");
-                }}
-              >
-                <Filter size={16} />
-              </Button>
-              {admin && (
-                <Button
-                  onClick={() => {
-                    setEditing(null);
-                    setDialogOpen(true);
-                  }}
-                >
-                  <Plus size={16} /> Новое
-                </Button>
-              )}
-            </div>
-            <div className="text-xs opacity-70">
-              Найдено {filtered.length} событий
-            </div>
-          </div>
-          <div className="mt-4 grid gap-4 md:grid-cols-3">
-            <div>
-              <div className="mb-2 text-xs font-semibold uppercase tracking-wide opacity-70">
-                Годы
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Chip
-                  label="Все"
-                  selected={year === "all"}
-                  onClick={() => setYear("all")}
-                />
-                {years.map((y) => (
-                  <Chip
-                    key={y}
-                    label={String(y)}
-                    selected={year === y}
-                    onClick={() => setYear(y)}
-                  />
-                ))}
-              </div>
-            </div>
-            <div>
-              <div className="mb-2 text-xs font-semibold uppercase tracking-wide opacity-70">
-                Месяцы
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Chip
-                  label="Все"
-                  selected={month === "all"}
-                  onClick={() => setMonth("all")}
-                />
-                {MONTHS.map((m, i) => (
-                  <Chip
-                    key={m}
-                    label={m.slice(0, 3)}
-                    selected={month === i}
-                    onClick={() => setMonth(i)}
-                  />
-                ))}
-              </div>
-            </div>
-            {allTags.length ? (
-              <div>
-                <div className="mb-2 text-xs font-semibold uppercase tracking-wide opacity-70">
-                  Теги
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  {allTags.map((t) => (
-                    <Chip
-                      key={t}
-                      label={t}
-                      selected={activeTags.includes(t)}
-                      onClick={() =>
-                        setActiveTags((prev) =>
-                          prev.includes(t)
-                            ? prev.filter((x) => x !== t)
-                            : [...prev, t]
-                        )
-                      }
-                    />
-                  ))}
-                </div>
-              </div>
-            ) : (
-              <div />
-            )}
-          </div>
-        </section>
+        <FiltersPanel
+          query={query}
+          setQuery={setQuery}
+          year={year}
+          setYear={setYear}
+          month={month}
+          setMonth={setMonth}
+          activeTags={activeTags}
+          setActiveTags={setActiveTags}
+          years={years}
+          allTags={allTags}
+          resetFilters={() => {
+            setActiveTags([]);
+            setYear("all");
+            setMonth("all");
+            setQuery("");
+          }}
+          resultsCount={filtered.length}
+          admin={admin}
+          onAdd={() => {
+            setEditing(null);
+            setDialogOpen(true);
+          }}
+        />
 
         {year !== "all" && (
           <div className="mb-4 flex items-center justify-between">
@@ -1434,50 +608,36 @@ export default function LifeTimelineApp() {
           </div>
         )}
 
-        <AnimatePresence mode="popLayout">
-          {view === "timeline" ? (
-            <motion.div
-              ref={listRef}
-              layout
-              className="relative grid gap-5 sm:gap-6 md:grid-cols-2"
-            >
-              {filtered.length ? (
-                filtered.map((ev, idx) => (
-                  <EventCard
-                    key={ev.id}
-                    ev={ev}
-                    className={cn(
-                      idx % 2 === 1 && "md:-translate-y-2",
-                      "transition-transform"
-                    )}
-                  />
-                ))
-              ) : (
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  className="rounded-2xl border border-black/10 bg-white/70 p-6 text-center text-sm text-neutral-600 dark:border-white/10 dark:bg-white/5 dark:text-neutral-300"
-                >
-                  Ничего не найдено. Попробуй изменить фильтры или добавить
-                  событие.
-                </motion.div>
-              )}
-            </motion.div>
-          ) : (
-            <MonthGrid />
-          )}
-        </AnimatePresence>
+        <EventList
+          events={filtered}
+          view={view}
+          listRef={listRef}
+          admin={admin}
+          onEdit={(ev) => {
+            setEditing(ev);
+            setDialogOpen(true);
+          }}
+          onDelete={(ev) => setDeleting(ev)}
+          onSelect={(ev) => {
+            setSelected(ev);
+            setDetailOpen(true);
+          }}
+        />
       </main>
 {/* ======= Модалка авторизации ======= */}
 <AnimatePresence>
-  {authOpen && (
-    <AuthDialog
-      open={authOpen}
-      mode={authMode}
-      onClose={()=>setAuthOpen(false)}
-      onSuccess={async()=>{ await refreshMe(); }}
-    />
-  )}
+    {authOpen && (
+      <AuthDialog
+        open={authOpen}
+        mode={authMode}
+        onClose={() => setAuthOpen(false)}
+        onSuccess={async () => {
+          await refreshMe();
+        }}
+        login={api.login}
+        register={api.register}
+      />
+    )}
 </AnimatePresence>
 {/* ======= Подтверждение удаления ======= */}
 <ConfirmDialog
@@ -1493,116 +653,49 @@ export default function LifeTimelineApp() {
   }}
   onCancel={() => setDeleting(null)}
 />
-{/* ======= Подтверждение выхода ======= */}
-<ConfirmDialog
-  open={logoutConfirmOpen}
-  title="Выйти из аккаунта?"
-  description="Сессия будет завершена, действия администратора станут недоступны."
-  confirmText="Выйти"
-  onConfirm={async ()=>{
-    try { await api.logout(); } finally {
-      setMe(null);
-      setLogoutConfirmOpen(false);
-    }
-  }}
-  onCancel={()=>setLogoutConfirmOpen(false)}
-/>
-      {/* Диалог добавления/редактирования */}
-      <AnimatePresence>
-        <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
-          <div className="sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-black/10 bg-white/95 px-4 py-3 dark:border-white/10 dark:bg-neutral-900/95">
-            <div className="flex items-center gap-2 text-lg font-semibold">
-              <Wand2 size={18} />{" "}
-              {editing ? "Редактировать событие" : "Новое событие"}
-            </div>
-            <Button variant="ghost" onClick={() => setDialogOpen(false)}>
-              <X size={18} />
-            </Button>
-          </div>
-          <div className="px-4">
-            <EventForm
-              initial={editing || undefined}
-              onCancel={() => setDialogOpen(false)}
-              onSubmit={(ev) => {
-                upsertEvent(ev);
-                setDialogOpen(false);
-                setEditing(null);
-              }}
-            />
-          </div>
-        </Dialog>
-      </AnimatePresence>
+  {/* ======= Подтверждение выхода ======= */}
+  <ConfirmDialog
+    open={logoutConfirmOpen}
+    title="Выйти из аккаунта?"
+    description="Сессия будет завершена, действия администратора станут недоступны."
+    confirmText="Выйти"
+    onConfirm={async () => {
+      try {
+        await api.logout();
+      } finally {
+        setMe(null);
+        setLogoutConfirmOpen(false);
+      }
+    }}
+    onCancel={() => setLogoutConfirmOpen(false)}
+  />
+  <AddDialog
+    open={dialogOpen}
+    initial={editing}
+    onClose={() => {
+      setDialogOpen(false);
+      setEditing(null);
+    }}
+    onSubmit={(ev) => {
+      upsertEvent(ev);
+      setDialogOpen(false);
+      setEditing(null);
+    }}
+  />
 
-      {/* Диалог деталей события */}
-      <AnimatePresence>
-        <Dialog open={detailOpen} onClose={() => setDetailOpen(false)}>
-          {selected && (
-            <>
-              <div className="sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-black/10 bg-white/95 px-4 py-3 dark:border-white/10 dark:bg-neutral-900/95">
-                <div className="flex items-center gap-2 text-lg font-semibold">
-                  <Info size={18} /> {selected.title}
-                </div>
-                <Button variant="ghost" onClick={() => setDetailOpen(false)}>
-                  <X size={18} />
-                </Button>
-              </div>
-              <div className="flex max-h-[85vh] flex-col gap-3 overflow-y-auto p-4">
-                <div className="text-sm opacity-80">
-                  <CalendarIcon className="-mt-0.5 inline" size={14} />{" "}
-                  {formatDateHuman(selected.date)}
-                </div>
-                {selected.imageData && (
-                  <div className="overflow-hidden rounded-2xl border border-black/10 dark:border-white/10 flex-shrink-0">
-                    <img
-                      src={selected.imageData}
-                      alt={selected.title}
-                      className="max-h-[60vh] w-full cursor-pointer object-cover"
-                      onClick={() => setImagePreview(selected.imageData!)}
-                    />
-                  </div>
-                )}
-                {selected.description && (
-                  <p className="text-sm leading-relaxed text-neutral-800 dark:text-neutral-200">
-                    {selected.description}
-                  </p>
-                )}
-                {selected.tags?.length ? (
-                  <div className="flex flex-wrap gap-2">
-                    {selected.tags.map((t) => (
-                      <span
-                        key={t}
-                        className="rounded-full border border-black/10 bg-black/5 px-2 py-0.5 text-xs dark:border-white/10 dark:bg-white/10"
-                      >
-                        #{t}
-                      </span>
-                    ))}
-                  </div>
-                ) : null}
-                {admin && (
-                  <div className="mt-2 flex items-center justify-end gap-2">
-                    <Button
-                      variant="soft"
-                      onClick={() => {
-                        setEditing(selected);
-                        setDetailOpen(false);
-                        setDialogOpen(true);
-                      }}
-                    >
-                      <Edit3 size={16} /> Редактировать
-                    </Button>
-                    <Button
-                      variant="outline"
-                      onClick={() => setDeleting(selected)}
-                    >
-                      <Trash2 size={16} /> Удалить
-                    </Button>
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-        </Dialog>
-      </AnimatePresence>
+  <DetailDialog
+    open={detailOpen}
+    event={selected}
+    admin={admin}
+    onClose={() => setDetailOpen(false)}
+    onEdit={(ev) => {
+      setEditing(ev);
+      setDialogOpen(true);
+      setDetailOpen(false);
+    }}
+    onDelete={(ev) => setDeleting(ev)}
+    onImagePreview={(src) => setImagePreview(src)}
+  />
 
       <AnimatePresence>
         <Dialog open={!!imagePreview} onClose={() => setImagePreview(null)}>

--- a/src/components/AddDialog.tsx
+++ b/src/components/AddDialog.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Wand2, X } from "lucide-react";
+import { Button, Dialog } from "./ui";
+import EventForm from "./EventForm";
+import { EventItem } from "../types";
+
+interface Props {
+  open: boolean;
+  initial?: EventItem | null;
+  onClose: () => void;
+  onSubmit: (ev: EventItem) => void;
+}
+
+export default function AddDialog({ open, initial, onClose, onSubmit }: Props) {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <div className="sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-black/10 bg-white/95 px-4 py-3 dark:border-white/10 dark:bg-neutral-900/95">
+        <div className="flex items-center gap-2 text-lg font-semibold">
+          <Wand2 size={18} /> {initial ? "Редактировать событие" : "Новое событие"}
+        </div>
+        <Button variant="ghost" onClick={onClose}>
+          <X size={18} />
+        </Button>
+      </div>
+      <div className="px-4">
+        <EventForm initial={initial || undefined} onCancel={onClose} onSubmit={onSubmit} />
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/AuthDialog.tsx
+++ b/src/components/AuthDialog.tsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useState } from "react";
+import { LogIn, Sparkles, X } from "lucide-react";
+import { Button, Dialog, Input } from "./ui";
+
+interface Props {
+  open: boolean;
+  mode: "login" | "register";
+  onClose: () => void;
+  onSuccess: () => void;
+  login: (email: string, password: string) => Promise<any>;
+  register: (email: string, password: string, invite: string) => Promise<any>;
+}
+
+export default function AuthDialog({
+  open,
+  mode,
+  onClose,
+  onSuccess,
+  login,
+  register,
+}: Props) {
+  const [form, setForm] = useState({ email: "", password: "", invite: "" });
+  const [showPass, setShowPass] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setError(null);
+  }, [mode, open]);
+
+  async function submit() {
+    setLoading(true);
+    setError(null);
+    try {
+      if (mode === "login") {
+        await login(form.email, form.password);
+      } else {
+        if (!form.invite) {
+          setError("Нужен инвайт-код");
+          setLoading(false);
+          return;
+        }
+        await register(form.email, form.password, form.invite);
+      }
+      onSuccess();
+      onClose();
+    } catch (e: any) {
+      setError(e?.message || "Ошибка авторизации");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!open) return null;
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <div className="sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-black/10 bg-white/95 px-4 py-3 dark:border-white/10 dark:bg-neutral-900/95">
+        <div className="flex items-center gap-2 text-lg font-semibold">
+          {mode === "login" ? (
+            <>
+              <LogIn size={18} /> Вход
+            </>
+          ) : (
+            <>
+              <Sparkles size={18} /> Регистрация
+            </>
+          )}
+        </div>
+        <Button variant="ghost" onClick={onClose}>
+          <X size={18} />
+        </Button>
+      </div>
+
+      <div className="p-4">
+        <div className="grid gap-3">
+          <div className="grid gap-1">
+            <label className="text-xs opacity-70">Email</label>
+            <Input
+              type="email"
+              placeholder="you@example.com"
+              value={form.email}
+              onChange={(e) => setForm({ ...form, email: e.target.value })}
+            />
+          </div>
+
+          <div className="grid gap-1">
+            <label className="text-xs opacity-70">Пароль</label>
+            <div className="relative">
+              <Input
+                type={showPass ? "text" : "password"}
+                placeholder="••••••••"
+                value={form.password}
+                onChange={(e) =>
+                  setForm({ ...form, password: e.target.value })
+                }
+                className="pr-10"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPass((v) => !v)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-xs opacity-70 hover:opacity-100"
+              >
+                {showPass ? "Скрыть" : "Показать"}
+              </button>
+            </div>
+            <p className="text-[11px] opacity-60">Мин. 6 символов</p>
+          </div>
+
+          {mode === "register" && (
+            <div className="grid gap-1">
+              <label className="text-xs opacity-70">Инвайт-код</label>
+              <Input
+                placeholder="XXXX-XXXX"
+                value={form.invite}
+                onChange={(e) => setForm({ ...form, invite: e.target.value })}
+              />
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-xl border border-red-200/60 bg-red-50/80 px-3 py-2 text-xs text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
+              {error}
+            </div>
+          )}
+
+          <div className="mt-1 flex items-center justify-between">
+            <button
+              type="button"
+              className="text-xs opacity-70 hover:opacity-100 underline underline-offset-4"
+              onClick={() => {
+                alert("Скоро добавим восстановление пароля 🙂");
+              }}
+            >
+              Забыли пароль?
+            </button>
+            <span className="text-xs opacity-70"></span>
+          </div>
+        </div>
+
+        <div className="mt-4 flex items-center justify-between">
+          <div className="text-xs opacity-70">
+            {mode === "login" ? "Нет аккаунта?" : "Уже есть аккаунт?"}{" "}
+            <button
+              className="underline underline-offset-4 hover:opacity-100 opacity-80"
+              onClick={() => {
+                const ev = new CustomEvent("switch-auth-mode", {
+                  detail: mode === "login" ? "register" : "login",
+                });
+                window.dispatchEvent(ev);
+              }}
+            >
+              {mode === "login" ? "Зарегистрируйтесь" : "Войти"}
+            </button>
+          </div>
+
+          <Button onClick={submit} disabled={loading}>
+            {loading ? (
+              "..."
+            ) : mode === "login" ? (
+              <>
+                <LogIn size={16} /> Войти
+              </>
+            ) : (
+              <>
+                <Sparkles size={16} /> Зарегистрироваться
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/DetailDialog.tsx
+++ b/src/components/DetailDialog.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { Calendar as CalendarIcon, Edit3, Info, Trash2, X } from "lucide-react";
+import { Button, Dialog } from "./ui";
+import { EventItem } from "../types";
+import { formatDateHuman } from "../utils/helpers";
+
+interface Props {
+  open: boolean;
+  event: EventItem | null;
+  admin: boolean;
+  onClose: () => void;
+  onEdit: (ev: EventItem) => void;
+  onDelete: (ev: EventItem) => void;
+  onImagePreview: (src: string) => void;
+}
+
+export default function DetailDialog({
+  open,
+  event,
+  admin,
+  onClose,
+  onEdit,
+  onDelete,
+  onImagePreview,
+}: Props) {
+  if (!open || !event) return null;
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <div className="sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-black/10 bg-white/95 px-4 py-3 dark:border-white/10 dark:bg-neutral-900/95">
+        <div className="flex items-center gap-2 text-lg font-semibold">
+          <Info size={18} /> {event.title}
+        </div>
+        <Button variant="ghost" onClick={onClose}>
+          <X size={18} />
+        </Button>
+      </div>
+      <div className="flex max-h-[85vh] flex-col gap-3 overflow-y-auto p-4">
+        <div className="text-sm opacity-80">
+          <CalendarIcon className="-mt-0.5 inline" size={14} /> {formatDateHuman(event.date)}
+        </div>
+        {event.imageData && (
+          <div className="overflow-hidden rounded-2xl border border-black/10 dark:border-white/10 flex-shrink-0">
+            <img
+              src={event.imageData}
+              alt={event.title}
+              className="max-h-[60vh] w-full cursor-pointer object-cover"
+              onClick={() => onImagePreview(event.imageData!)}
+            />
+          </div>
+        )}
+        {event.description && (
+          <p className="text-sm leading-relaxed text-neutral-800 dark:text-neutral-200">
+            {event.description}
+          </p>
+        )}
+        {event.tags?.length ? (
+          <div className="flex flex-wrap gap-2">
+            {event.tags.map((t) => (
+              <span
+                key={t}
+                className="rounded-full border border-black/10 bg-black/5 px-2 py-0.5 text-xs dark:border-white/10 dark:bg-white/10"
+              >
+                #{t}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        {admin && (
+          <div className="mt-2 flex items-center justify-end gap-2">
+            <Button
+              variant="soft"
+              onClick={() => onEdit(event)}
+            >
+              <Edit3 size={16} /> Редактировать
+            </Button>
+            <Button variant="outline" onClick={() => onDelete(event)}>
+              <Trash2 size={16} /> Удалить
+            </Button>
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -1,0 +1,168 @@
+import React, { useState } from "react";
+import { Tag, Image as ImageIcon, X } from "lucide-react";
+import { Button, Chip, Input, Textarea, cn } from "./ui";
+import { EventItem } from "../types";
+import { uid } from "../utils/helpers";
+
+interface Props {
+  initial?: Partial<EventItem>;
+  onSubmit: (e: EventItem) => void;
+  onCancel: () => void;
+}
+
+export default function EventForm({ initial, onSubmit, onCancel }: Props) {
+  const [date, setDate] = useState(
+    initial?.date || new Date().toISOString().slice(0, 10)
+  );
+  const [title, setTitle] = useState(initial?.title || "");
+  const [description, setDescription] = useState(initial?.description || "");
+  const [tags, setTags] = useState((initial?.tags as string[]) || []);
+  const [tagInput, setTagInput] = useState("");
+  const [color, setColor] = useState(initial?.color || "");
+  const [imageData, setImageData] = useState<string | undefined>(initial?.imageData);
+
+  function addTag() {
+    const t = tagInput.trim();
+    if (!t) return;
+    if (!tags.includes(t)) setTags([...tags, t]);
+    setTagInput("");
+  }
+
+  function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith("image/")) return alert("Выберите изображение");
+    const reader = new FileReader();
+    reader.onload = () => setImageData(String(reader.result));
+    reader.readAsDataURL(file);
+  }
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const ev: EventItem = {
+          id: (initial?.id as string) || uid(),
+          date,
+          title: title.trim() || "Без названия",
+          description: description.trim(),
+          tags,
+          color: color || undefined,
+          imageData,
+        };
+        onSubmit(ev);
+      }}
+      className="flex min-h-0 flex-1 flex-col"
+    >
+      <div className="grid max-h-[60vh] gap-3 overflow-y-auto pr-1">
+        <div className="grid gap-1">
+          <label className="text-xs text-black/60 dark:text-white/60">Дата</label>
+          <Input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            required
+          />
+        </div>
+        <div className="grid gap-1">
+          <label className="text-xs text-black/60 dark:text-white/60">Заголовок</label>
+          <Input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Например: Переезд в новый город"
+          />
+        </div>
+        <div className="grid gap-1">
+          <label className="text-xs text-black/60 dark:text-white/60">Описание</label>
+          <Textarea
+            rows={4}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Короткая история/заметки"
+          />
+        </div>
+        <div className="grid gap-1">
+          <label className="text-xs text-black/60 dark:text-white/60">Теги</label>
+          <div className="flex gap-2">
+            <Input
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              placeholder="Добавить тег"
+              onKeyDown={(e) => e.key === "Enter" && (e.preventDefault(), addTag())}
+            />
+            <Button variant="soft" onClick={addTag} type="button">
+              <Tag size={16} /> Добавить
+            </Button>
+          </div>
+          <div className="flex flex-wrap gap-2 pt-1">
+            {tags.map((t) => (
+              <Chip key={t} label={t} onClick={() => setTags(tags.filter((x) => x !== t))} />
+            ))}
+          </div>
+        </div>
+        <div className="grid gap-3">
+          <label className="text-xs text-black/60 dark:text-white/60">Цвет акцента</label>
+          <div className="flex flex-wrap items-center gap-3">
+            {["#60a5fa", "#34d399", "#f472b6", "#fb923c", "#a78bfa", "#fbbf24"].map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => setColor(c)}
+                className={cn(
+                  "h-6 w-6 rounded-full border border-black/20 dark:border-white/10",
+                  color === c && "ring-2 ring-offset-2 ring-indigo-400"
+                )}
+                style={{ background: c }}
+                aria-label={`Выбрать цвет ${c}`}
+              />
+            ))}
+          </div>
+        </div>
+        <div className="grid gap-3">
+          <label className="text-xs text-black/60 dark:text-white/60 flex items-center gap-2">
+            <ImageIcon size={16} /> Фото (необязательно, 1 шт)
+          </label>
+          <div className="flex flex-col items-start gap-2">
+            <label
+              className={cn(
+                "relative flex cursor-pointer items-center justify-center rounded-xl border-2 border-dashed border-indigo-300/60 bg-white/60 px-4 py-4 text-sm font-medium transition hover:bg-indigo-50 dark:bg-white/10 dark:hover:bg-indigo-950/20",
+                imageData && "border-solid border-indigo-400 bg-indigo-50/60 dark:bg-indigo-900/30"
+              )}
+              style={{ minHeight: 120, minWidth: 180, width: "100%", maxWidth: 320 }}
+            >
+              {imageData ? (
+                <img src={imageData} alt="Превью" className="h-28 w-full object-cover rounded-lg shadow" />
+              ) : (
+                <div className="flex flex-col items-center justify-center w-full h-full gap-2 py-2 text-indigo-500 dark:text-indigo-300">
+                  <ImageIcon size={32} />
+                  <span className="text-xs opacity-70">Выбрать изображение</span>
+                </div>
+              )}
+              <input
+                type="file"
+                accept="image/*"
+                onChange={onFile}
+                className="absolute inset-0 h-full w-full opacity-0 cursor-pointer"
+                tabIndex={-1}
+                aria-label="Выбрать изображение"
+              />
+            </label>
+            {imageData && (
+              <Button variant="outline" className="mt-1" onClick={() => setImageData(undefined)} type="button">
+                <X size={14} /> Удалить фото
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="sticky bottom-0 -mx-4 mt-3 flex justify-end gap-2 border-t border-black/10 bg-white/90 px-4 py-3 backdrop-blur dark:border-white/10 dark:bg-neutral-900/90">
+        <Button variant="outline" onClick={onCancel} type="button">
+          <X size={16} /> Отмена
+        </Button>
+        <Button type="submit">
+          Сохранить
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -1,0 +1,146 @@
+import React, { RefObject } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Calendar as CalendarIcon, Edit3, Trash2 } from "lucide-react";
+import { Button, cn } from "./ui";
+import { EventItem } from "../types";
+import { formatDateHuman, getMonth, MONTHS } from "../utils/helpers";
+
+interface Props {
+  events: EventItem[];
+  view: "timeline" | "calendar";
+  listRef: RefObject<HTMLDivElement>;
+  admin: boolean;
+  onEdit: (ev: EventItem) => void;
+  onDelete: (ev: EventItem) => void;
+  onSelect: (ev: EventItem) => void;
+}
+
+export default function EventList({
+  events,
+  view,
+  listRef,
+  admin,
+  onEdit,
+  onDelete,
+  onSelect,
+}: Props) {
+  function EventCard({ ev, className = "" }: { ev: EventItem; className?: string }) {
+    const accent = ev.color || "#8b5cf6";
+    return (
+      <motion.button
+        layout
+        data-timeline-card
+        tabIndex={0}
+        onClick={() => onSelect(ev)}
+        initial={{ y: 10, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ y: -10, opacity: 0 }}
+        className={cn(
+          "group relative flex h-45 w-full flex-col overflow-hidden text-left rounded-3xl border border-black/5 p-5 shadow-lg backdrop-blur transition hover:shadow-2xl focus:outline-none focus:ring-2 focus:ring-indigo-300",
+          "bg-white/70 dark:bg-white/5",
+          className
+        )}
+        style={{ backgroundImage: `linear-gradient(180deg, ${accent}0f, transparent 55%)` }}
+      >
+        <div className="absolute inset-x-4 top-0 h-1 rounded-b-full" style={{ background: accent }} />
+        <div className="flex items-start justify-between gap-3">
+          <div className="text-base font-semibold text-neutral-900 dark:text-white sm:text-lg">
+            {ev.title}
+          </div>
+          {admin && (
+            <div className="flex items-center gap-2 opacity-90" onClick={(e) => e.stopPropagation()}>
+              <Button
+                variant="soft"
+                onClick={() => onEdit(ev)}
+              >
+                <Edit3 size={16} />
+              </Button>
+              <Button variant="outline" onClick={() => onDelete(ev)}>
+                <Trash2 size={16} />
+              </Button>
+            </div>
+          )}
+        </div>
+        <div className="pt-1 text-sm text-neutral-700 dark:text-neutral-300">
+          <span className="inline-flex items-center gap-1 rounded-full bg-black/5 px-2 py-0.5 text-xs dark:bg-white/10">
+            <CalendarIcon size={14} /> {formatDateHuman(ev.date)}
+          </span>
+        </div>
+        {ev.description && (
+          <p className="pt-3 text-sm leading-relaxed text-neutral-800 dark:text-neutral-200 line-clamp-1">
+            {ev.description}
+          </p>
+        )}
+        {ev.tags?.length ? (
+          <div className="mt-auto pt-3 flex flex-wrap gap-2">
+            {ev.tags.map((t) => (
+              <span
+                key={t}
+                className="rounded-full bg-indigo-500/10 px-2 py-0.5 text-xs text-indigo-700 dark:text-indigo-300"
+                style={{ border: `1px solid ${accent}55` }}
+              >
+                #{t}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </motion.button>
+    );
+  }
+
+  function MonthGrid() {
+    const grouped: Record<number, EventItem[]> = {};
+    for (let i = 0; i < 12; i++) grouped[i] = [];
+    for (const ev of events) grouped[getMonth(ev.date)].push(ev);
+    return (
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {MONTHS.map((m, i) => (
+          <div
+            key={m}
+            className="rounded-3xl border border-black/10 bg-white/60 p-4 dark:border-white/10 dark:bg-white/5"
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <div className="font-semibold text-neutral-900 dark:text-white">{m}</div>
+              <div className="text-xs opacity-60">{grouped[i].length} событий</div>
+            </div>
+            <div className="grid gap-2">
+              {grouped[i].length ? (
+                grouped[i].map((ev) => <EventCard key={ev.id} ev={ev} />)
+              ) : (
+                <div className="text-sm text-neutral-600 dark:text-neutral-400">Нет событий</div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <AnimatePresence mode="popLayout">
+      {view === "timeline" ? (
+        <motion.div ref={listRef} layout className="relative grid gap-5 sm:gap-6 md:grid-cols-2">
+          {events.length ? (
+            events.map((ev, idx) => (
+              <EventCard
+                key={ev.id}
+                ev={ev}
+                className={cn(idx % 2 === 1 && "md:-translate-y-2", "transition-transform")}
+              />
+            ))
+          ) : (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="rounded-2xl border border-black/10 bg-white/70 p-6 text-center text-sm text-neutral-600 dark:border-white/10 dark:bg-white/5 dark:text-neutral-300"
+            >
+              Ничего не найдено. Попробуй изменить фильтры или добавить событие.
+            </motion.div>
+          )}
+        </motion.div>
+      ) : (
+        <MonthGrid />
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/FiltersPanel.tsx
+++ b/src/components/FiltersPanel.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { Filter, Plus, Search } from "lucide-react";
+import { Button, Chip, Input } from "./ui";
+import { MONTHS } from "../utils/helpers";
+
+interface Props {
+  query: string;
+  setQuery: (s: string) => void;
+  year: number | "all";
+  setYear: (v: number | "all") => void;
+  month: number | "all";
+  setMonth: (v: number | "all") => void;
+  activeTags: string[];
+  setActiveTags: React.Dispatch<React.SetStateAction<string[]>>;
+  years: number[];
+  allTags: string[];
+  resetFilters: () => void;
+  resultsCount: number;
+  admin: boolean;
+  onAdd: () => void;
+}
+
+export default function FiltersPanel({
+  query,
+  setQuery,
+  year,
+  setYear,
+  month,
+  setMonth,
+  activeTags,
+  setActiveTags,
+  years,
+  allTags,
+  resetFilters,
+  resultsCount,
+  admin,
+  onAdd,
+}: Props) {
+  return (
+    <section className="-mt-6 mb-6 rounded-3xl border border-black/10 bg-white/70 p-4 shadow-xl backdrop-blur dark:border-white/10 dark:bg-white/5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-1 items-center gap-2">
+          <div className="relative w-full">
+            <Search className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 opacity-60" size={18} />
+            <Input
+              className="pl-10"
+              placeholder="Поиск по событиям, описаниям и тегам"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          </div>
+          <Button variant="soft" onClick={resetFilters}>
+            <Filter size={16} />
+          </Button>
+          {admin && (
+            <Button onClick={onAdd}>
+              <Plus size={16} /> Новое
+            </Button>
+          )}
+        </div>
+        <div className="text-xs opacity-70">Найдено {resultsCount} событий</div>
+      </div>
+      <div className="mt-4 grid gap-4 md:grid-cols-3">
+        <div>
+          <div className="mb-2 text-xs font-semibold uppercase tracking-wide opacity-70">Годы</div>
+          <div className="flex flex-wrap gap-2">
+            <Chip label="Все" selected={year === "all"} onClick={() => setYear("all")} />
+            {years.map((y) => (
+              <Chip key={y} label={String(y)} selected={year === y} onClick={() => setYear(y)} />
+            ))}
+          </div>
+        </div>
+        <div>
+          <div className="mb-2 text-xs font-semibold uppercase tracking-wide opacity-70">Месяцы</div>
+          <div className="flex flex-wrap gap-2">
+            <Chip label="Все" selected={month === "all"} onClick={() => setMonth("all")} />
+            {MONTHS.map((m, i) => (
+              <Chip key={m} label={m.slice(0, 3)} selected={month === i} onClick={() => setMonth(i)} />
+            ))}
+          </div>
+        </div>
+        {allTags.length ? (
+          <div>
+            <div className="mb-2 text-xs font-semibold uppercase tracking-wide opacity-70">Теги</div>
+            <div className="flex flex-wrap gap-2">
+              {allTags.map((t) => (
+                <Chip
+                  key={t}
+                  label={t}
+                  selected={activeTags.includes(t)}
+                  onClick={() =>
+                    setActiveTags((prev) =>
+                      prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]
+                    )
+                  }
+                />
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -1,0 +1,175 @@
+import React, { useEffect } from "react";
+import { motion } from "framer-motion";
+
+export function cn(...classes: (string | boolean | undefined | null)[]) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function Button({
+  className,
+  children,
+  onClick,
+  variant = "primary",
+  type = "button",
+  disabled,
+}: React.PropsWithChildren<{
+  className?: string;
+  onClick?: () => void;
+  variant?: "primary" | "ghost" | "outline" | "soft";
+  type?: "button" | "submit" | "reset";
+  disabled?: boolean;
+}>) {
+  const base =
+    "inline-flex items-center gap-2 rounded-2xl px-4 py-2 text-sm font-medium shadow-sm transition active:scale-[.98]";
+  const variants: Record<string, string> = {
+    primary:
+      "bg-gradient-to-br from-indigo-500 to-fuchsia-500 text-white hover:opacity-95",
+    ghost:
+      "bg-transparent hover:bg-white/10 text-foreground dark:text-white border border-transparent",
+    outline:
+      "border border-black/10 dark:border-white/10 hover:bg-black/5 dark:hover:bg-white/10",
+    soft: "bg-black/5 dark:bg-white/10 hover:bg-black/10 dark:hover:bg-white/20",
+  };
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        base,
+        variants[variant],
+        disabled && "opacity-60 cursor-not-allowed",
+        className
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function Chip({
+  selected,
+  label,
+  onClick,
+}: {
+  selected?: boolean;
+  label: string;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "px-3 py-1 rounded-full text-xs border transition",
+        selected
+          ? "bg-indigo-500/90 text-white border-transparent"
+          : "bg-white/70 dark:bg-white/5 backdrop-blur border-black/10 dark:border-white/10 hover:bg-white"
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+export function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      {...props}
+      className={cn(
+        "w-full rounded-xl border border-black/10 dark:border-white/10 bg-white/80 dark:bg-white/5 px-3 py-2 text-sm outline-none",
+        "focus:ring-2 focus:ring-indigo-400/60",
+        props.className
+      )}
+    />
+  );
+}
+
+export function Textarea(props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      {...props}
+      className={cn(
+        "w-full rounded-xl border border-black/10 dark:border-white/10 bg-white/80 dark:bg-white/5 px-3 py-2 text-sm outline-none",
+        "focus:ring-2 focus:ring-indigo-400/60",
+        props.className
+      )}
+    />
+  );
+}
+
+export function Dialog({
+  open,
+  onClose,
+  children,
+}: React.PropsWithChildren<{ open: boolean; onClose: () => void }>) {
+  useEffect(() => {
+    if (!open) return;
+    const original = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = original;
+    };
+  }, [open]);
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center">
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <motion.div
+        initial={{ y: 20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ y: 10, opacity: 0 }}
+        className="relative z-10 w-[92vw] max-w-2xl rounded-2xl border border-white/10 bg-white/95 shadow-2xl dark:bg-neutral-900/95"
+      >
+        <div className="flex max-h-[85vh] flex-col">{children}</div>
+      </motion.div>
+    </div>
+  );
+}
+
+export function ConfirmDialog({
+  open,
+  title = "Вы уверены?",
+  description,
+  confirmText = "Да",
+  cancelText = "Отмена",
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  title?: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  if (!open) return null;
+  return (
+    <Dialog open={open} onClose={onCancel}>
+      <div className="p-4">
+        <h3 className="text-lg font-semibold">{title}</h3>
+        {description && <p className="mt-2 text-sm opacity-80">{description}</p>}
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="outline" onClick={onCancel}>
+            {cancelText}
+          </Button>
+          <Button onClick={onConfirm}>{confirmText}</Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+export default {
+  cn,
+  Button,
+  Chip,
+  Input,
+  Textarea,
+  Dialog,
+  ConfirmDialog,
+};

--- a/src/hooks/useDialogs.ts
+++ b/src/hooks/useDialogs.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { EventItem } from "../types";
+
+export function useDialogs() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [authOpen, setAuthOpen] = useState(false);
+  const [authMode, setAuthMode] = useState<"login" | "register">("login");
+  const [logoutConfirmOpen, setLogoutConfirmOpen] = useState(false);
+  const [editing, setEditing] = useState<EventItem | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [selected, setSelected] = useState<EventItem | null>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [deleting, setDeleting] = useState<EventItem | null>(null);
+
+  useEffect(() => {
+    function onSwitch(e: any) {
+      const next = e?.detail === "register" ? "register" : "login";
+      setAuthMode(next as any);
+    }
+    window.addEventListener("switch-auth-mode", onSwitch as any);
+    return () => window.removeEventListener("switch-auth-mode", onSwitch as any);
+  }, []);
+
+  return {
+    dialogOpen,
+    setDialogOpen,
+    authOpen,
+    setAuthOpen,
+    authMode,
+    setAuthMode,
+    logoutConfirmOpen,
+    setLogoutConfirmOpen,
+    editing,
+    setEditing,
+    detailOpen,
+    setDetailOpen,
+    selected,
+    setSelected,
+    imagePreview,
+    setImagePreview,
+    settingsOpen,
+    setSettingsOpen,
+    deleting,
+    setDeleting,
+  };
+}

--- a/src/hooks/useEventFilters.ts
+++ b/src/hooks/useEventFilters.ts
@@ -1,0 +1,71 @@
+import { useMemo, useState } from "react";
+import { EventItem } from "../types";
+import { getMonth, getYear } from "../utils/helpers";
+
+export function useEventFilters(events: EventItem[]) {
+  const [query, setQuery] = useState("");
+  const [year, setYear] = useState<number | "all">("all");
+  const [month, setMonth] = useState<number | "all">("all");
+  const [activeTags, setActiveTags] = useState<string[]>([]);
+  const [view, setView] = useState<"timeline" | "calendar">("timeline");
+
+  const allTags = useMemo(() => {
+    const s = new Set<string>();
+    for (const e of events) e.tags.forEach((t) => s.add(t));
+    return Array.from(s).sort((a, b) => a.localeCompare(b));
+  }, [events]);
+
+  const years = useMemo(() => {
+    const ys = new Set<number>();
+    for (const e of events) ys.add(getYear(e.date));
+    return Array.from(ys).sort((a, b) => a - b);
+  }, [events]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return events
+      .filter((e) => (year === "all" ? true : getYear(e.date) === year))
+      .filter((e) => (month === "all" ? true : getMonth(e.date) === month))
+      .filter((e) =>
+        !activeTags.length
+          ? true
+          : activeTags.every((t) =>
+              e.tags.map((x) => x.toLowerCase()).includes(t.toLowerCase())
+            )
+      )
+      .filter((e) =>
+        !q
+          ? true
+          : [e.title, e.description, e.tags.join(" ")]
+              .filter(Boolean)
+              .some((s) => s!.toLowerCase().includes(q))
+      )
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  }, [events, query, year, month, activeTags]);
+
+  const currentYearIndex = year === "all" ? -1 : years.indexOf(year);
+  function prevYear() {
+    if (currentYearIndex > 0) setYear(years[currentYearIndex - 1]);
+  }
+  function nextYear() {
+    if (currentYearIndex < years.length - 1) setYear(years[currentYearIndex + 1]);
+  }
+
+  return {
+    query,
+    setQuery,
+    year,
+    setYear,
+    month,
+    setMonth,
+    activeTags,
+    setActiveTags,
+    view,
+    setView,
+    allTags,
+    years,
+    filtered,
+    prevYear,
+    nextYear,
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import './index.css'
-import LifeTimelineApp from './App'
+import App from './App'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <LifeTimelineApp />
+    <App />
   </React.StrictMode>,
 )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+export type EventItem = {
+  id: string;
+  date: string; // ISO 8601: YYYY-MM-DD
+  title: string;
+  description?: string;
+  tags: string[];
+  color?: string;
+  emoji?: string; // устар.
+  imageData?: string;
+};

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,79 @@
+export function uid() {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
+export function formatDateHuman(iso: string) {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export function getYear(iso: string) {
+  return new Date(iso).getFullYear();
+}
+
+export function getMonth(iso: string) {
+  return new Date(iso).getMonth();
+}
+
+export const MONTHS = [
+  "Январь",
+  "Февраль",
+  "Март",
+  "Апрель",
+  "Май",
+  "Июнь",
+  "Июль",
+  "Август",
+  "Сентябрь",
+  "Октябрь",
+  "Ноябрь",
+  "Декабрь",
+];
+
+import { EventItem } from "../types";
+
+export function downloadFile(
+  filename: string,
+  content: string,
+  type = "application/json"
+) {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+export function toICS(events: EventItem[]) {
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Life Timeline//EN",
+  ];
+  for (const ev of events) {
+    const dt = new Date(ev.date);
+    const dtStart = dt.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+    const dtEndDate = new Date(dt.getTime() + 24 * 60 * 60 * 1000);
+    const dtEnd = dtEndDate.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+    lines.push("BEGIN:VEVENT");
+    lines.push(`UID:${ev.id}@life-timeline`);
+    lines.push(`DTSTAMP:${dtStart}`);
+    lines.push(`DTSTART:${dtStart}`);
+    lines.push(`DTEND:${dtEnd}`);
+    lines.push(`SUMMARY:${ev.title}`);
+    if (ev.description)
+      lines.push(`DESCRIPTION:${ev.description.replace(/\n/g, "\\n")}`);
+    if (ev.tags?.length) lines.push(`CATEGORIES:${ev.tags.join(",")}`);
+    lines.push("END:VEVENT");
+  }
+  lines.push("END:VCALENDAR");
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
- split large App into dedicated components for filters, event list and dialogs
- move shared UI primitives and date helpers to separate modules
- add hooks for event filters and dialog state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1dd2c4e6c83328d7f1baca812440f