### PR TITLE
feat: support partitioned cookies

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,7 @@
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
-        "express": "^4.19.2",
+        "express": "^4.21.2",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.6.1",

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "express": "^4.19.2",
+    "express": "^4.21.2",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.6.1",

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -35,6 +35,7 @@ function cookieOpts() {
     sameSite: isLocal ? "lax" : "none",
     secure: isLocal ? false : true,
     maxAge: 7 * 24 * 3600 * 1000,
+    ...(isLocal ? {} : { partitioned: true }),
   };
 }
 function setAuthCookie(res, payload) {


### PR DESCRIPTION
## Summary
- add `partitioned: true` to auth cookies in production
- update Express to v4.21.2 for partitioned cookie support

## Testing
- `npm install`
- `node server/src/index.js` *(fails: JWT_SECRET is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a2075c0b888332b3969c0c53adce71