### PR TITLE
feat: allow user registration without invite

### DIFF
--- a/server/src/db.js
+++ b/server/src/db.js
@@ -22,7 +22,7 @@ function applyToJSON(schema) {
 const UserSchema = new mongoose.Schema({
   email: { type: String, unique: true, required: true },
   passwordHash: { type: String, required: true },
-  role: { type: String, enum: ["admin", "user"], default: "admin" },
+  role: { type: String, enum: ["admin", "user"], default: "user" },
 }, { timestamps: true });
 
 const EventSchema = new mongoose.Schema({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,36 +36,6 @@ import { formatDateHuman, uid, downloadFile, toICS } from "./utils/helpers";
 const THEME_KEY = "life-timeline-theme";
 
 /* =========================
-   Примеры (локальный fallback)
-========================= */
-const SAMPLE: EventItem[] = [
-  {
-    id: uid(),
-    date: "2019-07-12",
-    title: "Первое большое путешествие",
-    description: "Море, фото на плёнку и чувство полной свободы.",
-    tags: ["путешествия", "лето"],
-    color: "#60a5fa",
-  },
-  {
-    id: uid(),
-    date: "2021-11-05",
-    title: "Первый релиз собственного плагина",
-    description: "Долгие ночи за клавиатурой окупились.",
-    tags: ["код", "релиз"],
-    color: "#34d399",
-  },
-  {
-    id: uid(),
-    date: "2023-02-14",
-    title: "Особенный день",
-    description: "Кофе, снег и тёплый разговор.",
-    tags: ["личное"],
-    color: "#f472b6",
-  },
-];
-
-/* =========================
    Основное приложение
 ========================= */
 export default function LifeTimelineApp() {
@@ -84,30 +54,35 @@ export default function LifeTimelineApp() {
 
   // Данные теперь с сервера
   const [events, setEvents] = useState<EventItem[]>([]);
-   const [me, setMe] = useState<MeUser | null>(null);
-   const admin = Boolean(me);
+  const [me, setMe] = useState<MeUser | null>(null);
+  const logged = Boolean(me);
+  const admin = me?.role === "admin";
 
-   async function refreshMe() {
-     try {
-       const r = await api.me();
-       setMe(r.user);
-     } catch {
-       setMe(null);
-     }
-   }
-   async function refreshEvents() {
-     try {
-       const r = await api.getEvents();
-       setEvents(r.events || []);
-     } catch {
-       setEvents(SAMPLE); /* fallback чтобы не пусто */
-     }
-   }
+  async function refreshMe() {
+    try {
+      const r = await api.me();
+      setMe(r.user);
+    } catch {
+      setMe(null);
+    }
+  }
+  async function refreshEvents() {
+    try {
+      const r = await api.getEvents();
+      setEvents(r.events || []);
+    } catch {
+      setEvents([]);
+    }
+  }
 
-   useEffect(() => {
-     refreshMe();
-     refreshEvents();
-   }, []);
+  useEffect(() => {
+    refreshMe();
+  }, []);
+
+  useEffect(() => {
+    if (me) refreshEvents();
+    else setEvents([]);
+  }, [me]);
 
    const {
      query,
@@ -387,21 +362,21 @@ export default function LifeTimelineApp() {
                   </div>
                 )}
               </div>
-                          {!admin ? (
-              <Button variant="outline" onClick={handleLogin}>
-                <LogIn size={16} /> Войти
-              </Button>
-            ) : (
-              <>
-                <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 rounded-xl bg-white/70 dark:bg-white/10 border border-black/10 dark:border-white/10 text-xs">
-                  <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
-                  {me?.email}
-                </div>
-                <Button variant="outline" onClick={handleLogout}>
-                  <LogOut size={16} /> Выйти
+              {!logged ? (
+                <Button variant="outline" onClick={handleLogin}>
+                  <LogIn size={16} /> Войти
                 </Button>
-              </>
-            )}
+              ) : (
+                <>
+                  <div className="hidden sm:flex items-center gap-2 px-3 py-1.5 rounded-xl bg-white/70 dark:bg-white/10 border border-black/10 dark:border-white/10 text-xs">
+                    <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
+                    {me?.email}
+                  </div>
+                  <Button variant="outline" onClick={handleLogout}>
+                    <LogOut size={16} /> Выйти
+                  </Button>
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/src/api.ts
+++ b/src/api.ts
@@ -56,10 +56,12 @@ export const api = {
       localStorage.removeItem(TOKEN_KEY);
     return r;
   },
-  register: async (email: string, password: string, invite: string) => {
+  register: async (email: string, password: string, invite?: string) => {
+    const payload: any = { email, password };
+    if (invite) payload.invite = invite;
     const r = await http<{ user: MeUser; token?: string }>("/api/auth/register", {
       method: "POST",
-      body: JSON.stringify({ email, password, invite }),
+      body: JSON.stringify(payload),
     });
     if (r.token) {
       authToken = r.token;

--- a/src/components/AuthDialog.tsx
+++ b/src/components/AuthDialog.tsx
@@ -9,7 +9,7 @@ interface Props {
   onClose: () => void;
   onSuccess: () => void;
   login: (email: string, password: string) => Promise<any>;
-  register: (email: string, password: string, invite: string) => Promise<any>;
+  register: (email: string, password: string, invite?: string) => Promise<any>;
 }
 
 export default function AuthDialog({
@@ -36,12 +36,7 @@ export default function AuthDialog({
       if (mode === "login") {
         await login(form.email, form.password);
       } else {
-        if (!form.invite) {
-          setError("Нужен инвайт-код");
-          setLoading(false);
-          return;
-        }
-        await register(form.email, form.password, form.invite);
+        await register(form.email, form.password, form.invite || undefined);
       }
       onSuccess();
       onClose();
@@ -109,9 +104,9 @@ export default function AuthDialog({
 
           {mode === "register" && (
             <div className="grid gap-1">
-              <label className="text-xs opacity-70">Инвайт-код</label>
+              <label className="text-xs opacity-70">Инвайт-код (для админов)</label>
               <Input
-                placeholder="XXXX-XXXX"
+                placeholder="необязательно"
                 value={form.invite}
                 onChange={(e) => setForm({ ...form, invite: e.target.value })}
               />


### PR DESCRIPTION
## Summary
- allow sign up without invite for regular users
- require login to view events and restrict changes to admins
- remove invite requirement from registration dialog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `node --check server/src/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68a50273705c833287a3fcfd1b6aa746