### PR TITLE
fix: properly clear auth cookie on logout

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -45,7 +45,10 @@ function setAuthCookie(res, token) {
   res.cookie("token", token, cookieOpts());
 }
 function clearAuthCookie(res) {
-  res.clearCookie("token", cookieOpts());
+  // Using res.clearCookie may fail when additional attributes like
+  // `partitioned` are present, so overwrite the cookie with an
+  // immediately expired one using the same options.
+  res.cookie("token", "", { ...cookieOpts(), maxAge: 0 });
 }
 function auth(req, res, next) {
   let token = req.cookies.token;


### PR DESCRIPTION
## Summary
- ensure logout overwrites auth cookie with expired one so session ends correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5b19b65688332a8dec7d4db2e1723