### PR TITLE
Fix logout request header

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -15,9 +15,9 @@ let authToken: string | null =
 
 export async function http<T = any>(path: string, opts: RequestInit = {}): Promise<T> {
   const headers: Record<string, string> = {
-    "Content-Type": "application/json",
     ...(opts.headers ? (opts.headers as Record<string, string>) : {}),
   };
+  if (opts.body !== undefined) headers["Content-Type"] = "application/json";
   if (authToken) headers["Authorization"] = `Bearer ${authToken}`;
   const res = await fetch(API_BASE + path, {
     credentials: "include",


### PR DESCRIPTION
## Summary
- avoid sending JSON header on requests without body to prevent logout failure

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5b441db3c83329af5f47ecc601be8