### PR TITLE
feat: add admin user management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
   FileDown,
   Trophy,
   AlertCircle,
+  Users,
 } from "lucide-react";
 import { Button, Dialog, ConfirmDialog, Input } from "./components/ui";
 import FiltersPanel from "./components/FiltersPanel";
@@ -27,6 +28,7 @@ import EventList from "./components/EventList";
 import AuthDialog from "./components/AuthDialog";
 import AddDialog from "./components/AddDialog";
 import DetailDialog from "./components/DetailDialog";
+import UsersDialog from "./components/UsersDialog";
 import { useEventFilters } from "./hooks/useEventFilters";
 import { useDialogs } from "./hooks/useDialogs";
 import { EventItem } from "./types";
@@ -119,12 +121,14 @@ export default function LifeTimelineApp() {
      setDetailOpen,
      selected,
      setSelected,
-     imagePreview,
-     setImagePreview,
-     settingsOpen,
-     setSettingsOpen,
-   deleting,
-   setDeleting,
+    imagePreview,
+    setImagePreview,
+    settingsOpen,
+    setSettingsOpen,
+    usersOpen,
+    setUsersOpen,
+    deleting,
+    setDeleting,
   } = useDialogs();
 
   const [unlockOpen, setUnlockOpen] = useState(false);
@@ -391,6 +395,15 @@ export default function LifeTimelineApp() {
                     </button>
                     {admin && (
                       <>
+                        <button
+                          className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-sm hover:bg-black/5 dark:hover:bg-white/10"
+                          onClick={() => {
+                            setSettingsOpen(false);
+                            setUsersOpen(true);
+                          }}
+                        >
+                          <Users size={16} /> Пользователи
+                        </button>
                         <label className="flex w-full cursor-pointer items-center gap-2 rounded-xl px-3 py-2 text-sm hover:bg-black/5 dark:hover:bg-white/10">
                           <Upload size={16} /> Импорт JSON
                           <input
@@ -625,6 +638,8 @@ export default function LifeTimelineApp() {
     onDelete={(ev) => setDeleting(ev)}
     onImagePreview={(src) => setImagePreview(src)}
   />
+
+  <UsersDialog open={usersOpen} onClose={() => setUsersOpen(false)} />
 
   <Dialog open={unlockOpen} onClose={() => setUnlockOpen(false)}>
     <div className="p-6 grid gap-4">

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,6 +8,7 @@ const API_BASE: string =
     : (import.meta as any).env?.VITE_API_BASE || "";
 
 export type MeUser = { id: string; email: string; role: "admin" | "user" };
+export type AdminUser = { id: string; email: string; role: string; codes: string[] };
 
 const TOKEN_KEY = "auth-token";
 let authToken: string | null =
@@ -89,5 +90,15 @@ export const api = {
     http<{ event: EventItem }>("/api/events/unlock", {
       method: "POST",
       body: JSON.stringify({ code }),
+    }),
+  getUsers: () => http<{ users: AdminUser[] }>("/api/admin/users"),
+  grantLegendary: (userId: string, code: string) =>
+    http<{ ok: true }>(`/api/admin/users/${userId}/legendary`, {
+      method: "POST",
+      body: JSON.stringify({ code }),
+    }),
+  revokeLegendary: (userId: string, code: string) =>
+    http<{ ok: true }>(`/api/admin/users/${userId}/legendary/${code}`, {
+      method: "DELETE",
     }),
 };

--- a/src/components/UsersDialog.tsx
+++ b/src/components/UsersDialog.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import { api, AdminUser } from "../api";
+import { Dialog, Button, Input } from "./ui";
+
+export default function UsersDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [codes, setCodes] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (open) refresh();
+  }, [open]);
+
+  async function refresh() {
+    try {
+      const r = await api.getUsers();
+      setUsers(r.users);
+    } catch {}
+  }
+
+  async function addCode(id: string) {
+    const code = codes[id];
+    if (!code) return;
+    try {
+      await api.grantLegendary(id, code);
+      setCodes((prev) => ({ ...prev, [id]: "" }));
+      refresh();
+    } catch {}
+  }
+
+  async function removeCode(id: string, code: string) {
+    try {
+      await api.revokeLegendary(id, code);
+      refresh();
+    } catch {}
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <div className="p-6 w-[90vw] max-w-xl max-h-[80vh] overflow-y-auto grid gap-4">
+        <h3 className="text-lg font-semibold">Пользователи</h3>
+        {users.map((u) => (
+          <div key={u.id} className="border rounded-xl p-3">
+            <div className="text-sm font-medium">{u.email}</div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {u.codes.map((c) => (
+                <span
+                  key={c}
+                  className="flex items-center gap-1 rounded-full bg-black/5 dark:bg-white/10 px-2 py-1 text-xs"
+                >
+                  {c}
+                  <button
+                    onClick={() => removeCode(u.id, c)}
+                    className="opacity-60 hover:opacity-100"
+                  >
+                    <Trash2 size={12} />
+                  </button>
+                </span>
+              ))}
+            </div>
+            <div className="mt-2 flex gap-2">
+              <Input
+                value={codes[u.id] || ""}
+                onChange={(e) =>
+                  setCodes((prev) => ({ ...prev, [u.id]: e.target.value }))
+                }
+                placeholder="Код"
+              />
+              <Button onClick={() => addCode(u.id)}>
+                <Plus size={16} /> Добавить
+              </Button>
+            </div>
+          </div>
+        ))}
+        <div className="flex justify-end">
+          <Button variant="outline" onClick={onClose}>
+            Закрыть
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/hooks/useDialogs.ts
+++ b/src/hooks/useDialogs.ts
@@ -12,6 +12,7 @@ export function useDialogs() {
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [deleting, setDeleting] = useState<EventItem | null>(null);
+  const [usersOpen, setUsersOpen] = useState(false);
 
   useEffect(() => {
     function onSwitch(e: any) {
@@ -41,6 +42,8 @@ export function useDialogs() {
     setImagePreview,
     settingsOpen,
     setSettingsOpen,
+    usersOpen,
+    setUsersOpen,
     deleting,
     setDeleting,
   };


### PR DESCRIPTION
## Summary
- allow admins to list users and grant or revoke legendary event codes
- add Users dialog and menu entry for admin-only user management
- expose admin user management endpoints in API client

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad876fb4bc8332ba2350ceadda63f0