### PR TITLE
Fix card image display

### DIFF
--- a/src/components/DetailDialog.tsx
+++ b/src/components/DetailDialog.tsx
@@ -43,7 +43,7 @@ export default function DetailDialog({
             <img
               src={event.imageData}
               alt={event.title}
-              className="max-h-[60vh] w-full cursor-pointer object-cover"
+              className="max-h-[60vh] w-full cursor-pointer object-contain"
               onClick={() => onImagePreview(event.imageData!)}
             />
           </div>

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -200,7 +200,11 @@ export default function EventForm({ initial, onSubmit, onCancel }: Props) {
               style={{ minHeight: 120, minWidth: 180, width: "100%", maxWidth: 320 }}
             >
               {imageData ? (
-                <img src={imageData} alt="Превью" className="h-28 w-full object-cover rounded-lg shadow" />
+                <img
+                  src={imageData}
+                  alt="Превью"
+                  className="max-h-28 max-w-full object-contain rounded-lg shadow"
+                />
               ) : (
                 <div className="flex flex-col items-center justify-center w-full h-full gap-2 py-2 text-indigo-500 dark:text-indigo-300">
                   <ImageIcon size={32} />


### PR DESCRIPTION
## Summary
- prevent event images from being cropped by using `object-contain`
- limit image size in event form preview to avoid oversized photos

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aef2e82a3883328e72176017eae0ea